### PR TITLE
Not strip trailing whitespace from markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,9 +13,20 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
+[readme.txt,*.md,*.markdown]
+trim_trailing_whitespace = false
+
+[js-tests/**/*.js]
+indent_style = space
+indent_size = 2
+
 [*.json]
 indent_style = space
 indent_size = 2
 
 [*.txt,wp-config-sample.php]
 end_of_line = crlf
+
+[.scss-lint.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Updated .editorconfig file. Trailing whitespace has meaning
in markdown, so it should not be removed on save.